### PR TITLE
Add Spring Boot welcome API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,13 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+# Maven build output
+/target/
+
+# IDE specific files
+.idea/
+*.iml
+*.ipr
+*.iws
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>sample-api-for-codex</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>sample-api-for-codex</name>
+    <description>Sample Spring Boot REST API</description>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/demo/SampleApiForCodexApplication.java
+++ b/src/main/java/com/example/demo/SampleApiForCodexApplication.java
@@ -1,0 +1,12 @@
+package com.example.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SampleApiForCodexApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SampleApiForCodexApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/demo/controller/WelcomeController.java
+++ b/src/main/java/com/example/demo/controller/WelcomeController.java
@@ -1,0 +1,13 @@
+package com.example.demo.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class WelcomeController {
+
+    @GetMapping("/welcome")
+    public String welcome() {
+        return "Welcome to the sample API!";
+    }
+}

--- a/src/test/java/com/example/demo/controller/WelcomeControllerTest.java
+++ b/src/test/java/com/example/demo/controller/WelcomeControllerTest.java
@@ -1,0 +1,26 @@
+package com.example.demo.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class WelcomeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void welcomeEndpointReturnsMessage() throws Exception {
+        mockMvc.perform(get("/welcome"))
+            .andExpect(status().isOk())
+            .andExpect(content().string("Welcome to the sample API!"));
+    }
+}


### PR DESCRIPTION
## Summary
- Initialize Spring Boot project with web and test dependencies
- Implement `/welcome` REST endpoint returning a welcome message
- Add unit test verifying `/welcome` endpoint response and update `.gitignore`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4f50be748327893e4d97883b4522